### PR TITLE
Engtools #307: use non-docker runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ build ci image:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/machine:$CURRENT_IMAGE_VERSION
 
 .build_base:
-  tags: [ "runner:docker", "size:large"  ]
+  tags: [ "runner:main", "size:large"  ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/machine:$CURRENT_IMAGE_VERSION
 
 build:


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
