### PR TITLE
Revert "Engtools #307: use non-docker runners"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ build ci image:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/machine:$CURRENT_IMAGE_VERSION
 
 .build_base:
-  tags: [ "runner:main", "size:large"  ]
+  tags: [ "runner:docker", "size:large"  ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/machine:$CURRENT_IMAGE_VERSION
 
 build:


### PR DESCRIPTION
Reverts DataDog/machine#4 due to issue with gopath/short test: https://gitlab.ddbuild.io/DataDog/machine/-/jobs/15654553