### PR TITLE
Engtools #307: pass keypair setting even if launch template is used for now

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -742,15 +742,16 @@ func (d *Driver) innerCreate() error {
 		var instanceConfig ec2.RunInstancesInput
 		if d.LaunchTemplateId != "" || d.LaunchTemplateName != "" {
 			log.Info("Entering Datadog Forked Behavior")
-			log.Info("Launching instance using Launch Template, non-network interface (vpc, subnet, sg) related flags")
+			log.Info("Launching instance using Launch Template, ignoring flags other than network interface (vpc, subnet, sg) related and keypair flags")
 			instanceConfig = ec2.RunInstancesInput{
-				MinCount: aws.Int64(1),
-				MaxCount: aws.Int64(1),
+				KeyName:           &d.KeyName,
 				LaunchTemplate: &ec2.LaunchTemplateSpecification{
 					LaunchTemplateName: &d.LaunchTemplateName,
 					LaunchTemplateId:   &d.LaunchTemplateId,
 					Version:            &d.LaunchTemplateVersion,
 				},
+				MinCount: aws.Int64(1),
+				MaxCount: aws.Int64(1),
 				NetworkInterfaces: netSpecs,
 			}
 		} else {


### PR DESCRIPTION
We should change to using a fixed keypair managed by our bake process, with a private key that the spawning runner can pick up from SSM, but for now this needs to be set to allow the auto keypairing to work